### PR TITLE
fix: replace StructureMatcher with direct position matching in BORNINFO

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Ver. 1.1.1 (2026)
 
+- Fixed a bug in BORNINFO generation where `StructureMatcher.get_transformation()`
+  returned non-identity atom mappings for highly symmetric crystals (e.g. CdAs2,
+  I4₁/amd), causing Born effective charge tensors to be assigned to the wrong atoms
+  and reversing the sign of off-diagonal components for symmetry-related atom pairs.
+  Replaced with direct nearest-neighbour matching in fractional coordinates.
+
 - Arrange the workflow related to --analyze_with_larger_sc, --scph, and --four options.
 
 

--- a/auto_kappa/io/born.py
+++ b/auto_kappa/io/born.py
@@ -17,8 +17,6 @@ import xmltodict
 
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.core import Lattice, Structure
-from pymatgen.analysis.structure_matcher import StructureMatcher
-
 from auto_kappa.io.fcs import FCSxml
 # from auto_kappa.structure import change_structure_format
 
@@ -92,34 +90,66 @@ class BORNINFO:
             self.set_prim_fcs()
         return self.alm.structure
     
-    def get_transformation(self, params={"ltol": 0.05, "stol": 0.1, "angle_tol": 0.5}):
-        ## Get transformation from VASP primitive to FC primitive
-        matcher = StructureMatcher(primitive_cell=False, **params)
-        if not matcher.fit(self.vasp.structure, self.alm.structure):
-            msg = f"\n Structures in vasprun.xml and force constants file do not match."
+    def get_transformation(self, tol_frac=0.15):
+        """ Find atom mapping from VASP primitive to FC primitive by nearest-position matching.
+
+        StructureMatcher.get_transformation() is intentionally avoided here because it may
+        find non-trivial crystallographic symmetry transformations (e.g. screw axes) even
+        for identical structures, causing Born effective charges to be assigned to the wrong
+        atoms in BORNINFO.  Direct nearest-neighbour matching in fractional coordinates
+        always returns the position-preserving mapping and is therefore correct.
+        """
+        vasp_sites = list(self.vasp.structure)
+        alm_sites = list(self.alm.structure)
+
+        if len(vasp_sites) != len(alm_sites):
+            msg = f"\n Structures in vasprun.xml and force constants file have different numbers of atoms."
             msg += f"\n - VASP file       : {self.file_vasp}"
             msg += f"\n - Force constants : {self.file_fcs}"
             logger.error(msg)
             sys.exit()
-        
-        tmat_v2a, ftrans_v2a, map_v2a = \
-            matcher.get_transformation(self.vasp.structure, self.alm.structure)
-        
-        ## Get rotation matrix from VASP to FC primitive
+
+        ## Match each VASP atom to the nearest ALM atom of the same species.
+        ## Distances are evaluated in fractional coordinates with periodic images.
+        map_v2a = []
+        used_alm = set()
+        for i, vsite in enumerate(vasp_sites):
+            best_j, best_d = -1, float('inf')
+            for j, asite in enumerate(alm_sites):
+                if j in used_alm:
+                    continue
+                if str(vsite.specie) != str(asite.specie):
+                    continue
+                diff = vsite.frac_coords - asite.frac_coords
+                diff -= np.round(diff)   # minimum image
+                dist = float(np.max(np.abs(diff)))
+                if dist < best_d:
+                    best_d = dist
+                    best_j = j
+            if best_j == -1 or best_d > tol_frac:
+                msg = f"\n Cannot match VASP atom {i} ({vsite.specie}) to any atom in the force-constants structure"
+                msg += f"\n (nearest distance in fractional coords: {best_d:.4f}, tolerance: {tol_frac})"
+                msg += f"\n - VASP file       : {self.file_vasp}"
+                msg += f"\n - Force constants : {self.file_fcs}"
+                logger.error(msg)
+                sys.exit()
+            map_v2a.append(best_j)
+            used_alm.add(best_j)
+
+        ## Rotation matrix from VASP lattice to FC primitive lattice
         L_vasp = self.vasp.structure.lattice.matrix
         L_fc = self.alm.structure.lattice.matrix
         R_v2a = np.linalg.inv(L_fc) @ L_vasp
-        return tmat_v2a, ftrans_v2a, map_v2a, R_v2a
-        
+        return map_v2a, R_v2a
+
     def set_born_info(self):
         """ Get Born effective charge and dielectric tensor for ALM calculation
         1. Read vasprun.xml to get Born effective charge and dielectric tensor
-        2. Get transformed dielectric tensor and Born effective charge. 
+        2. Get transformed dielectric tensor and Born effective charge.
         """
-        # tmat : transformation (supercell) matrix
-        # fracT : fractional translation vector
-        # map   : mapping of atom indices from VASP to ALM
-        tmat_v2a, fracT_v2a, map_v2a, R_v2a = self.get_transformation()
+        # map   : mapping of atom indices from VASP to ALM, map[idx_vasp] = idx_alm
+        # R     : rotation matrix from VASP lattice to FC primitive lattice
+        map_v2a, R_v2a = self.get_transformation()
         self.alm.dielectric_tensor = _transform_dielectric_tensor(self.vasp.dielectric_tensor, R_v2a)
         self.alm.born_charges = _transform_born_charges(self.vasp.born_charges, R_v2a, map_v2a)
         # return self.alm.dielectric_tensor, self.alm.born_charges

--- a/tests/test_born.py
+++ b/tests/test_born.py
@@ -1,0 +1,126 @@
+"""
+Tests for auto_kappa.io.born — Born effective charge mapping.
+
+The key regression tested here: StructureMatcher.get_transformation() can
+return non-identity atom mappings (e.g. [1,0,...]) for highly symmetric
+crystals such as CdAs2 (I4_1/amd) even when the two structures are identical.
+The fixed implementation uses direct nearest-position matching, which always
+returns the position-preserving mapping.
+"""
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+from auto_kappa.io.born import BORNINFO, _transform_born_charges
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_borninfo(vasp_frac, alm_frac, species, lattice_matrix):
+    """Return a BORNINFO instance whose VASP and ALM structures are stubbed."""
+    from pymatgen.core import Structure, Lattice
+
+    lattice = Lattice(lattice_matrix)
+    vasp_struct = Structure(lattice, species, vasp_frac)
+    alm_struct  = Structure(lattice, species, alm_frac)
+
+    b = object.__new__(BORNINFO)
+    b.file_vasp = "dummy_vasprun.xml"
+    b.file_fcs  = "dummy_fcs.xml"
+    b.vasp = MagicMock()
+    b.alm  = MagicMock()
+    b.vasp.structure = vasp_struct
+    b.alm.structure  = alm_struct
+    return b
+
+
+# CdAs2 primitive cell lattice (I4_1/amd, rhombohedral setting, in Angstrom)
+CDAS2_LATTICE = np.array([
+    [-3.9830465,  3.9830465,  2.3371877],
+    [ 3.9830465, -3.9830465,  2.3371877],
+    [ 3.9830465,  3.9830465, -2.3371877],
+])
+
+CDAS2_SPECIES = ["Cd", "Cd", "As", "As", "As", "As"]
+
+CDAS2_FRAC = np.array([
+    [0.25, 0.75, 0.5 ],   # Cd1
+    [0.5,  0.5,  0.0 ],   # Cd2
+    [0.311, 0.061, 0.75],  # As1
+    [0.061, 0.311, 0.75],  # As2
+    [0.689, 0.939, 0.25],  # As3
+    [0.939, 0.689, 0.25],  # As4
+])
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_transformation
+# ---------------------------------------------------------------------------
+
+class TestGetTransformation:
+
+    def test_identity_mapping_for_identical_structures(self):
+        """Identical VASP and ALM structures must produce the identity mapping."""
+        b = _make_mock_borninfo(CDAS2_FRAC, CDAS2_FRAC, CDAS2_SPECIES, CDAS2_LATTICE)
+        map_v2a, R = b.get_transformation()
+        assert map_v2a == list(range(len(CDAS2_SPECIES))), \
+            f"Expected identity mapping, got {map_v2a}"
+
+    def test_rotation_is_identity_for_same_lattice(self):
+        """When both structures share the same lattice, R must be the identity."""
+        b = _make_mock_borninfo(CDAS2_FRAC, CDAS2_FRAC, CDAS2_SPECIES, CDAS2_LATTICE)
+        _, R = b.get_transformation()
+        np.testing.assert_allclose(R, np.eye(3), atol=1e-10)
+
+    def test_swapped_cd_atoms_detected(self):
+        """If ALM has Cd1 and Cd2 swapped, the mapping should reflect that."""
+        alm_frac = CDAS2_FRAC.copy()
+        alm_frac[0], alm_frac[1] = CDAS2_FRAC[1].copy(), CDAS2_FRAC[0].copy()
+
+        b = _make_mock_borninfo(CDAS2_FRAC, alm_frac, CDAS2_SPECIES, CDAS2_LATTICE)
+        map_v2a, _ = b.get_transformation()
+
+        # VASP Cd1 (idx 0) should map to ALM idx 1 (where Cd1 ended up)
+        assert map_v2a[0] == 1
+        # VASP Cd2 (idx 1) should map to ALM idx 0 (where Cd2 ended up)
+        assert map_v2a[1] == 0
+        # As atoms unchanged
+        assert map_v2a[2:] == [2, 3, 4, 5]
+
+    def test_no_structurematcher_import(self):
+        """StructureMatcher must not be imported in born.py (it was the source of the bug)."""
+        import auto_kappa.io.born as born_module
+        assert not hasattr(born_module, "StructureMatcher"), \
+            "StructureMatcher should not be imported in born.py"
+
+
+# ---------------------------------------------------------------------------
+# Tests for _transform_born_charges
+# ---------------------------------------------------------------------------
+
+class TestTransformBornCharges:
+
+    def _make_born(self, n=2, seed=0):
+        rng = np.random.default_rng(seed)
+        return [rng.random((3, 3)) for _ in range(n)]
+
+    def test_identity_mapping_and_rotation_leaves_charges_unchanged(self):
+        born = self._make_born(n=3)
+        R = np.eye(3)
+        mapping = [0, 1, 2]
+        result = _transform_born_charges(born, R, mapping)
+        np.testing.assert_allclose(result, np.array(born), atol=1e-12)
+
+    def test_swap_mapping_reorders_charges(self):
+        """map_v2a = [1, 0] means VASP atom 0 → ALM atom 1 and vice versa.
+        After inversion, BORNINFO atom 0 should get VASP atom 1's tensor."""
+        born = self._make_born(n=2)
+        R = np.eye(3)
+        mapping = [1, 0]   # VASP Cd1 → ALM pos 1, VASP Cd2 → ALM pos 0
+        result = _transform_born_charges(born, R, mapping)
+        # inv_map = argsort([1,0]) = [1,0]
+        # result[0] = born[1], result[1] = born[0]
+        np.testing.assert_allclose(result[0], born[1], atol=1e-12)
+        np.testing.assert_allclose(result[1], born[0], atol=1e-12)


### PR DESCRIPTION
StructureMatcher.get_transformation() can return non-identity atom mappings for highly symmetric crystals (e.g. CdAs2, I4_1/amd) even when the two structures are identical, because it exploits crystallographic symmetry operations such as screw axes.  This caused Born effective charge tensors in BORNINFO to be assigned to the wrong atoms, reversing the sign of off-diagonal components for symmetry-related atom pairs.

Replace with direct nearest-neighbour matching in fractional coordinates using the minimum-image convention.  This always returns the position-preserving mapping, which is what ALAMODE/ANPHON expects.

Also add tests/test_born.py covering identity mapping, swapped-atom detection, and absence of the StructureMatcher import.